### PR TITLE
Chore(WIN-2123): Handle kwargs properly for Ruby 3

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.6.9, 2.7.5, 3.0.3]
+        ruby_version: [2.7.8, 3.0.7]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/spec/active_operation/pipeline_spec.rb
+++ b/spec/active_operation/pipeline_spec.rb
@@ -230,8 +230,9 @@ describe ActiveOperation::Pipeline do
       expect { described_class.compose { use ->(a = 1) {} } }.to raise_error(ArgumentError)
     end
 
-    it "does not support optional keyword arguments as Ruby's reflection mechanism does not support accessing the default value which is required to setup the operation inputs correctly" do
-      expect { described_class.compose { use ->(a: 1) {} } }.to raise_error(ArgumentError)
+    it "supports optional keyword arguments" do
+      pipeline = described_class.compose { use ->(a: 1) { a } }
+      expect(pipeline.call(a: 2)).to eq(2)
     end
   end
 end


### PR DESCRIPTION
- Update class methods (perform, call, to_proc) to explicitly handle keyword arguments
- Add **kwargs parameter to handle keyword arguments separately from positional args
- Fix deprecation warnings related to keyword argument handling
- Maintain backward compatibility while preparing for Ruby 3.0

This change addresses the Ruby 2.7 deprecation warning: "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"

### Testing
* Tests
	* 	https://github.com/StackAdapt/active_operation/actions/runs/11632838267
* Tested in stackadapt-web: https://github.com/StackAdapt/stackadapt-web/pull/25153